### PR TITLE
Change outline class name for pbutton fix #134

### DIFF
--- a/src/components/lib/forms/PButton.vue
+++ b/src/components/lib/forms/PButton.vue
@@ -104,7 +104,7 @@ export default defineComponent({
             'rounded-md': props.rounded && !props.pilled,
 
             'solid': props.type === 'solid',
-            'outline': props.type === 'outline',
+            'outline-pbutton': props.type === 'outline',
             'soft': props.type === 'soft',
             'ghost': props.type === 'ghost',
             'disabled': props.disabled,
@@ -152,7 +152,7 @@ export default defineComponent({
     @apply bg-pink-500 hover:bg-pink-600 dark:focus:ring-offset-gray-dark-900 text-gray-light-50;
   }
 }
-.outline {
+.outline-pbutton {
   @apply border border-current shadow-sm font-semibold bg-transparent;
 
   &.teal {


### PR DESCRIPTION
<img width="936" height="273" alt="image" src="https://github.com/user-attachments/assets/536bbb2e-fb5e-441f-8a2a-4e3331923592" />